### PR TITLE
Modify nvidia list

### DIFF
--- a/Dockerfile.jetson-xavier
+++ b/Dockerfile.jetson-xavier
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y lbzip2 git wget unzip jq
 
 # Keep sources list at r32 for cuda 10 and cudnn 7
-RUN sed -i 's/r32.4 main/r32 main/g' /etc/apt/sources.list.d/nvidia.list && apt-get update
+RUN sed -i 's/r32.5 main/r32 main/g' /etc/apt/sources.list.d/nvidia.list && apt-get update
 
 # Install CUDA/cuDNN 
 RUN apt-get install -y cuda-toolkit-10-0 libcudnn7 libcudnn7-dev


### PR DESCRIPTION
The list in image balenalib/jetson-xavier-ubuntu:bionic in 2021/8/23 was 32.5 not 32.4, so modified it in Dockerfile.


From

RUN sed -i 's/r32.4 main/r32 main/g' /etc/apt/sources.list.d/nvidia.list && apt-get update

TO

RUN sed -i 's/r32.5 main/r32 main/g' /etc/apt/sources.list.d/nvidia.list && apt-get update